### PR TITLE
Switch from GATK 4.2 to Picard 3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.0 - 2023-10-06
+- Switch from GATK 4.2 to Picard 3.1. GATK 4.2 is 50 times slower than Picard for unknown reason.
+
 ## 2.0.0 - 2023-09-25
 - Switched from Picard 2.21 to GATK 4.2. This has been shown to produce significantly different LOD scores
 - Removed the `additionalParameters` parameter. That parameter was a bad design decision.

--- a/crosscheckFingerprints.wdl
+++ b/crosscheckFingerprints.wdl
@@ -22,8 +22,8 @@ workflow crosscheckFingerprints {
         dependencies:
         [
             {
-                name: "gatk/4.2.0.0",
-                url: "https://gatk.broadinstitute.org/hc/en-us/articles/360056798851--GATK-4-2-release"
+                name: "picard/3.1.0",
+                url: "https://github.com/broadinstitute/picard/releases/tag/3.1.0"
             },
             {
                 name: "crosscheckfingerprints-haplotype-map/20230324",
@@ -61,7 +61,7 @@ task runCrosscheckFingerprints {
         Int exitCodeWhenNoValidChecks = 0
         Float lodThreshold = 0.0
         String validationStringency = "SILENT"
-        String modules = "gatk/4.2.0.0 crosscheckfingerprints-haplotype-map/20230324"
+        String modules = "picard/3.1.0 crosscheckfingerprints-haplotype-map/20230324"
         Int threads = 4
         Int jobMemory = 6
         Int timeout = 6
@@ -87,7 +87,7 @@ task runCrosscheckFingerprints {
     command <<<
         set -eu -o pipefail
 
-        $GATK_ROOT/bin/gatk --java-options "-Xmx~{picardMaxMemMb}M" CrosscheckFingerprints \
+        java -Xmx~{picardMaxMemMb}M -jar $PICARD_ROOT/picard.jar CrosscheckFingerprints \
         ~{sep=" " inputCommand} \
         HAPLOTYPE_MAP=~{haplotypeMap} \
         OUTPUT=~{outputPrefix}.crosscheck_metrics.txt \

--- a/vidarrtest-regression.json.in
+++ b/vidarrtest-regression.json.in
@@ -30,7 +30,6 @@
                 }
             ],
             "crosscheckFingerprints.outputPrefix": "PCSI_TEST",
-            "crosscheckFingerprints.runCrosscheckFingerprints.additionalParameters": null,
             "crosscheckFingerprints.runCrosscheckFingerprints.crosscheckBy": null,
             "crosscheckFingerprints.runCrosscheckFingerprints.exitCodeWhenMismatch": null,
             "crosscheckFingerprints.runCrosscheckFingerprints.exitCodeWhenNoValidChecks": null,


### PR DESCRIPTION
GATK 4.2 has really bad performance for unknown reasons. Switching to Picard 3.1 did not change the output (test passed).